### PR TITLE
Avoid warning about closing unopened filehandle during destruction

### DIFF
--- a/lib/Log/Dispatch/File.pm
+++ b/lib/Log/Dispatch/File.pm
@@ -3,6 +3,8 @@ package Log::Dispatch::File;
 use strict;
 use warnings;
 
+use Scalar::Util qw(openhandle);
+
 use Log::Dispatch::Output;
 
 use base qw( Log::Dispatch::Output );
@@ -145,7 +147,7 @@ sub DESTROY {
 
     if ( $self->{fh} ) {
         my $fh = $self->{fh};
-        close $fh;
+        close $fh if openhandle($fh);
     }
 }
 


### PR DESCRIPTION
If the filehandle isn't open, then closing it throws a warning.  This could happen if the application blows up before the logging ever starts.  So to avoid the warning, we check if the filehandle is open before trying to close.  Scalar::Util::openhandle seems to be best way to do this.  Using tell() throws the same warning, and fileno() doesn't always give the right answer.
