### PR TITLE
Optimize the 'newline' callback

### DIFF
--- a/lib/Log/Dispatch/Output.pm
+++ b/lib/Log/Dispatch/Output.pm
@@ -166,9 +166,7 @@ sub _unique_name {
 }
 
 sub _add_newline_callback {
-    my %p = @_;
-
-    return $p{message} . "\n";
+    +{@_}->{message} . "\n"
 }
 
 1;


### PR DESCRIPTION
Much shorter optree for this hot log formatting sub.

To compare the optree:

```
perl -Ilib -MLog::Dispatch::Output -MO=Concise,Log::Dispatch::Output::_add_newline_callback -e0
```
