### PR TITLE
Add utf8 parameter for Log::Dispatch::Screen

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+- Added a utf8 parameter for Log::Dispatch::Screen. Patch by Ivan Baidakou
+  (basiliscos)
+
+
 2.44     2014-10-18
 
 - The fix for a buffered email output in the last release introduced a bug

--- a/lib/Log/Dispatch/Screen.pm
+++ b/lib/Log/Dispatch/Screen.pm
@@ -28,6 +28,14 @@ sub new {
     $self->_basic_init(%p);
     $self->{stderr} = exists $p{stderr} ? $p{stderr} : 1;
 
+    if( $self->{utf8} ) {
+        if( $self->{stderr} ) {
+            binmode STDERR, ":utf8";
+        } else {
+            binmode STDOUT, ":utf8";
+        }
+    }
+
     return $self;
 }
 
@@ -61,7 +69,8 @@ __END__
               'Screen',
               min_level => 'debug',
               stderr    => 1,
-              newline   => 1
+              newline   => 1,
+              utf8      => 1,
           ]
       ],
   );
@@ -88,6 +97,10 @@ parameters documented in L<Log::Dispatch::Output>:
 Indicates whether or not logging information should go to STDERR. If
 false, logging information is printed to STDOUT instead. This
 defaults to true.
+
+=item * utf8 (0 or 1)
+
+Set the utf8 option to a true value to enable printing wide utf8 characters.
 
 =back
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use utf8;
 
 use Test::More 0.88;
 use Test::Fatal;
@@ -313,6 +314,30 @@ SKIP:
 
     is(
         $text, 'testing screen',
+        "Log::Dispatch::Screen outputs to STDOUT"
+    );
+}
+
+# Log::Dispatch::Screen utf8 output
+{
+    my $dispatch = Log::Dispatch->new;
+
+    $dispatch->add(
+        Log::Dispatch::Screen->new(
+            name      => 'screen',
+            min_level => 'debug',
+            stderr    => 0,
+            utf8      => 1,
+        )
+    );
+
+    my $text;
+    tie *STDOUT, 'Test::Tie::STDOUT', \$text;
+    $dispatch->log( level => 'crit', message => 'I ♥ Log::Dispatch' );
+    untie *STDOUT;
+
+    is(
+        $text, 'I ♥ Log::Dispatch',
         "Log::Dispatch::Screen outputs to STDOUT"
     );
 }


### PR DESCRIPTION
Hi, 

The parameter is very similar one as in Log::Log4perl::Appender::Screen :)