### PR TITLE
fix threads usage with Perl 5.20

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+- Fixed again thread locking in Log::Dispatch::Syslog (didn't work at least
+  with Perl 5.20). Patch by David Schweikert.
+
 2.44     2014-10-18
 
 - The fix for a buffered email output in the last release introduced a bug

--- a/lib/Log/Dispatch/Syslog.pm
+++ b/lib/Log/Dispatch/Syslog.pm
@@ -62,7 +62,7 @@ sub _init {
     if ( $self->{lock} ) {
         require threads;
         require threads::shared;
-        threads::shared::share(\$thread_lock);
+        &threads::shared::share(\$thread_lock);
     }
 
     $self->{priorities} = [

--- a/lib/Log/Dispatch/Syslog.pm
+++ b/lib/Log/Dispatch/Syslog.pm
@@ -28,6 +28,7 @@ sub new {
 }
 
 my ($Ident) = $0 =~ /(.+)/;
+my $thread_lock;
 
 sub _init {
     my $self = shift;
@@ -61,6 +62,7 @@ sub _init {
     if ( $self->{lock} ) {
         require threads;
         require threads::shared;
+        threads::shared::share(\$thread_lock);
     }
 
     $self->{priorities} = [
@@ -74,8 +76,6 @@ sub _init {
         'EMERG'
     ];
 }
-
-my $thread_lock : shared = 0;
 
 sub log_message {
     my $self = shift;


### PR DESCRIPTION
Without this patch I get:

    lock can only be used on shared values at /opt/OSAGperlm/lib/Log/Dispatch/Syslog.pm line 86.
