### PR TITLE
Add authenticated SMTP to Log::Dispatch::Email::MailSender

### DIFF
--- a/lib/Log/Dispatch/Email/MailSender.pm
+++ b/lib/Log/Dispatch/Email/MailSender.pm
@@ -25,10 +25,25 @@ sub new {
     my $smtp = delete $p{smtp} || 'localhost';
     my $port = delete $p{port} || '25';
 
+    my $authid = delete $p{authid};
+    my $authpwd = delete $p{authpwd};
+    my $auth = delete $p{auth};
+    my $tls_required = delete $p{tls_required};
+    my $replyto = delete $p{replyto};
+    my $fake_from = delete $p{fake_from};
+
     my $self = $class->SUPER::new(%p);
 
     $self->{smtp} = $smtp;
     $self->{port} = $port;
+
+    $self->{authid} = $authid;
+    $self->{authpwd} = $authpwd;
+    $self->{auth} = $auth;
+    $self->{tls_required} = $tls_required;
+
+    $self->{fake_from} = $fake_from;
+    $self->{replyto} = $replyto;
 
     return $self;
 }
@@ -42,11 +57,17 @@ sub send_email {
         my $sender = Mail::Sender->new(
             {
                 from    => $self->{from} || 'LogDispatch@foo.bar',
-                replyto => $self->{from} || 'LogDispatch@foo.bar',
+                fake_from => $self->{fake_from},
+                replyto => $self->{replyto},
                 to      => ( join ',', @{ $self->{to} } ),
                 subject => $self->{subject},
                 smtp    => $self->{smtp},
                 port    => $self->{port},
+                authid  => $self->{authid},
+                authpwd => $self->{authpwd},
+                auth    => $self->{auth},
+                tls_required => $self->{tls_required},
+                #debug => \*STDERR,
             }
         );
 
@@ -102,6 +123,34 @@ The smtp server to connect to. This defaults to "localhost".
 =item * port ($)
 
 The port to use when connecting. This defaults to 25.
+
+=item * auth ($)
+
+Optional. The SMTP authentication protocol to use to login to the server. At the time of writing 
+Mail::Sender only supports LOGIN, PLAIN, CRAM-MD5 and NTLM.
+
+Some protocols have module dependencies. CRAM-MD5 depends on Digest::HMAC_MD5 and NTLM on Authen::NTLM.
+
+=item * authid ($)
+
+Optional. The username used to login to the server.
+
+=item * authpwd ($)
+
+Optional. The password used to login to the server.
+
+=item * tls_required ($)
+
+Optional. If you set this option to a true value, Mail::Sender will fail whenever it's unable to use TLS.
+
+=item * fake_from ($)
+
+The From address that will be shown in headers. If not specified we use the value of from.
+
+=item * replyto ($)
+
+The reply-to address.
+
 
 =back
 


### PR DESCRIPTION
This patch adds authenticated SMTP support to Log::Dispatch::Email::MailSender. It just passes through a few more arguments to Mail::Sender’s new() method. I have also decoupled “from” and “replyto” and added support for Mail::Sender's “fake_from”.