### PR TITLE
repair `t/08-screen.t` tests

### DIFF
--- a/t/08-screen.t
+++ b/t/08-screen.t
@@ -119,8 +119,8 @@ sub _run_helper {
         \undef,
         \$stdout,
         \$stderr, {
-            binmode_stdout => ':encoding(UTF-8)',
-            binmode_stderr => ':encoding(UTF-8)',
+            binmode_stdout => ':encoding(UTF-8):crlf',
+            binmode_stderr => ':encoding(UTF-8):crlf',
         },
     );
 


### PR DESCRIPTION
* append ':crlf' to binmode specification string, enabling text mode

* repairs a testing bug which only appears on systems with non-LF end-of-lines (eg, DOS/Win, MAC/OS-9)
* tests now complete without errors on both DOS/Win and *nix (ubuntu)
* fixes #11 (and ticket-id:106947 on rt.cpan.org)