### PR TITLE
Fixes bug #106495; log() level param can accept the level's integer

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+2.54    xxx
+
+- fixes bug #106495; log() now accepts level param as its integer equivalent
+
 2.53     2016-01-14
 
 - Actually fix File::Locked, this time with some actual tests.

--- a/lib/Log/Dispatch.pm
+++ b/lib/Log/Dispatch.pm
@@ -163,6 +163,16 @@ sub log {
     my $self = shift;
     my %p    = @_;
 
+    if ($p{level} =~ /[0-7]/){
+
+        my @levels = qw(
+            debug info notice warning error
+            critical alert emergency
+        );
+
+        $p{level} = $levels[$p{level}];
+    }
+
     return unless $self->would_log( $p{level} );
 
     $self->_log_to_outputs( $self->_prepare_message(%p) );
@@ -254,8 +264,11 @@ sub output {
 
 sub level_is_valid {
     shift;
-    my $level = shift
-        or Carp::croak('Logging level was not provided');
+    my $level = shift;
+
+    if (! defined $level) {
+        Carp::croak('Logging level was not provided');
+    }
 
     return $LEVELS{$level};
 }
@@ -403,9 +416,9 @@ made to the outputs or callbacks that the object contains are not shared.
 
 =head2 $dispatch->log( level => $, message => $ or \& )
 
-Sends the message (at the appropriate level) to all the
-output objects that the dispatcher contains (by calling the
-C<log_to> method repeatedly).
+Sends the message (at the appropriate level, which can be supplied as its name,
+shortname or its representative integer) to all the output objects that the
+dispatcher contains (by calling the C<log_to> method repeatedly).
 
 This method also accepts a subroutine reference as the message
 argument. This reference will be called only if there is an output

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
 
-use Data::Dumper;
 use Test::More 0.88;
 use Test::Fatal;
 
@@ -1130,9 +1129,6 @@ SKIP:
     $dispatch->log( level => 4,  message => "bug 106495 2\n" );
     $dispatch->log( level => 1,  message => "bug 106495 3\n" );
 
-    $dispatch->log( level => 0,  message => "bug 106495 3\n" );
-
-
     open my $fh, '<', $log or die $!;
     my @log = <$fh>;
     close $fh;
@@ -1143,6 +1139,42 @@ SKIP:
     is ($log[2], "bug 106495 1\n", 'nummerical level works with min_level 3 and level 3');
     is ($log[3], "bug 106495 2\n", 'nummerical level works with min_level 3 and level 4');
     is ($log[4], undef, 'using numerical level works with min_level 3 and level 1');
+}
+{# bug 106495
+
+    my $dispatch = Log::Dispatch->new;
+    my $log = File::Spec->catdir( $tempdir, 'emerg.log' );
+
+    $dispatch->add(
+        Log::Dispatch::File->new(
+            name      => 'file1',
+            min_level => 0,
+            filename  => $log,
+        )
+    );
+
+    $dispatch->log( level => 0,  message => "bug 106495 0\n" );
+    $dispatch->log( level => 1,  message => "bug 106495 1\n" );
+    $dispatch->log( level => 2,  message => "bug 106495 2\n" );
+    $dispatch->log( level => 3,  message => "bug 106495 3\n" );
+    $dispatch->log( level => 4,  message => "bug 106495 4\n" );
+    $dispatch->log( level => 5,  message => "bug 106495 5\n" );
+    $dispatch->log( level => 6,  message => "bug 106495 6\n" );
+    $dispatch->log( level => 7,  message => "bug 106495 7\n" );
+
+    open my $fh, '<', $log or die $!;
+    my @log = <$fh>;
+    close $fh;
+
+
+    is ($log[0], "bug 106495 0\n", 'at level 0, int works');
+    is ($log[1], "bug 106495 1\n", 'at level 1, int works');
+    is ($log[2], "bug 106495 2\n", 'at level 2, int works');
+    is ($log[3], "bug 106495 3\n", 'at level 3, int works');
+    is ($log[4], "bug 106495 4\n", 'at level 4, int works');
+    is ($log[5], "bug 106495 5\n", 'at level 5, int works');
+    is ($log[6], "bug 106495 6\n", 'at level 6, int works');
+    is ($log[7], "bug 106495 7\n", 'at level 7, int works');
 }
 
 done_testing();


### PR DESCRIPTION
- added tests
- updated Changes
- small POD update in log()