### PR TITLE
Ensure that $@ and $! are not changed in logging methods

### DIFF
--- a/lib/Log/Dispatch/Email/MailSend.pm
+++ b/lib/Log/Dispatch/Email/MailSend.pm
@@ -23,7 +23,7 @@ sub send_email {
     # Does this ever work for this module?
     $msg->set( 'From', $self->{from} ) if $self->{from};
 
-    local $?;
+    local ($?, $@, $SIG{__DIE__});
     eval {
         my $fh = $msg->open
             or die "Cannot open handle to mail program";

--- a/lib/Log/Dispatch/Email/MailSender.pm
+++ b/lib/Log/Dispatch/Email/MailSender.pm
@@ -52,7 +52,7 @@ sub send_email {
     my $self = shift;
     my %p    = @_;
 
-    local $?;
+    local ($?, $@, $SIG{__DIE__});
     eval {
         my $sender = Mail::Sender->new(
             {

--- a/lib/Log/Dispatch/Output.pm
+++ b/lib/Log/Dispatch/Output.pm
@@ -34,6 +34,7 @@ sub log {
 
     return unless $self->_should_log( $p{level} );
 
+    local $!;
     $p{message} = $self->_apply_callbacks(%p)
         if $self->{callbacks};
 

--- a/t/syslog.t
+++ b/t/syslog.t
@@ -67,4 +67,23 @@ local *Sys::Syslog::syslog = sub { push @log, [@_] };
     );
 }
 
+{
+    @log = ();
+   my $dispatch = Log::Dispatch->new;
+    $dispatch->add(
+        Log::Dispatch::Syslog->new(
+            name      => 'syslog',
+            min_level => 'debug',
+            socket    => { type => 'foo' },
+        )
+    );
+
+    eval { die "foo!" };
+
+    $dispatch->debug('Foo');
+
+    like($@, qr/^foo!/, '$@ is not changed');
+}
+
+
 done_testing();


### PR DESCRIPTION
Logging methods shouldn't modify globals. Specially `$@` and `$!`.