### PR TITLE
add remove_callback method

### DIFF
--- a/lib/Log/Dispatch.pm
+++ b/lib/Log/Dispatch.pm
@@ -449,6 +449,11 @@ Adds a callback (like those given during construction). It is added to the end
 of the list of callbacks. Note that this can also be called on individual
 output objects.
 
+=head2 $dispatch->remove_callback( $code )
+
+Remove the given callback from the list of callbacks. Note that this can also
+be called on individual output objects.
+
 =head2 $dispatch->callbacks()
 
 Returns a list of the callbacks in a given output.

--- a/lib/Log/Dispatch/Base.pm
+++ b/lib/Log/Dispatch/Base.pm
@@ -2,6 +2,7 @@ package Log::Dispatch::Base;
 
 use strict;
 use warnings;
+use Scalar::Util qw( refaddr );
 
 our $VERSION = '2.57';
 
@@ -45,6 +46,21 @@ sub add_callback {
     return;
 }
 
+sub remove_callback {
+    my $self  = shift;
+    my $value = shift;
+
+    Carp::carp("given value $value is not a valid callback")
+        unless ref $value eq 'CODE';
+
+    my $cb_id = refaddr $value;
+    my $cbs   = $self->{callbacks};
+    my ($i) = grep { refaddr $cbs->[$_] eq $cb_id } 0 .. $#$cbs;
+    splice @{ $self->{callbacks} }, $i, 1;
+
+    return;
+}
+
 1;
 
 # ABSTRACT: Code shared by dispatch and output objects.
@@ -52,6 +68,8 @@ sub add_callback {
 __END__
 
 =for Pod::Coverage add_callback
+
+=for Pod::Coverage remove_callback
 
 =head1 SYNOPSIS
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -950,10 +950,16 @@ SKIP:
     $dispatch->log( level => 'debug', message => 'foo' );
     is( $string, 'foo', 'first test w/o callback' );
 
+    my $cb = sub { return 'bar' };
     $string = '';
-    $dispatch->add_callback( sub { return 'bar' } );
+    $dispatch->add_callback($cb);
     $dispatch->log( level => 'debug', message => 'foo' );
     is( $string, 'bar', 'second call, callback overrides message' );
+
+    $string = '';
+    $dispatch->remove_callback($cb);
+    $dispatch->log( level => 'debug', message => 'foo' );
+    is( $string, 'foo', 'third call, callback is removed' );
 }
 
 {
@@ -973,10 +979,16 @@ SKIP:
     $dispatch->log( level => 'debug', message => 'foo' );
     is( $string, 'baz', 'first test gets orig callback result' );
 
+    my $cb = sub { return 'bar' };
     $string = '';
-    $dispatch->add_callback( sub { return 'bar' } );
+    $dispatch->add_callback($cb);
     $dispatch->log( level => 'debug', message => 'foo' );
     is( $string, 'bar', 'second call, callback overrides message' );
+
+    $string = '';
+    $dispatch->remove_callback($cb);
+    $dispatch->log( level => 'debug', message => 'foo' );
+    is( $string, 'baz', 'third call, output callback is removed' );
 }
 
 {


### PR DESCRIPTION
This method allows us to remove a callback which was previously added by
add_callback. With this and some use of Scope::Guard, we can achieve
scoped logging contexts which add information to all log lines in
a given scope.