### PR TITLE
Improve level validation and canonicalisation logic

### DIFF
--- a/lib/Log/Dispatch.pm
+++ b/lib/Log/Dispatch.pm
@@ -140,10 +140,6 @@ sub log {
     my $self = shift;
     my %p    = @_;
 
-    if ( exists $p{level} && $p{level} =~ /\A[0-7]\z/ ) {
-        $p{level} = $OrderedLevels[ $p{level} ];
-    }
-
     return unless $self->would_log( $p{level} );
 
     $self->_log_to_outputs( $self->_prepare_message(%p) );
@@ -239,6 +235,10 @@ sub level_is_valid {
 
     if ( !defined $level ) {
         Carp::croak('Logging level was not provided');
+    }
+
+    if ( $level =~ /\A[0-9]+\z/ && $level <= $#OrderedLevels ) {
+        return $OrderedLevels[$level];
     }
 
     return $CanonicalLevelNames{$level};

--- a/lib/Log/Dispatch/Output.pm
+++ b/lib/Log/Dispatch/Output.pm
@@ -65,18 +65,20 @@ sub _basic_init {
 
     $self->{name} = $p{name} || $self->_unique_name();
 
-    $self->{min_level} = $self->_level_as_number( $p{min_level} );
-    die "Invalid level specified for min_level"
+    eval { $self->{min_level} = $self->_level_as_number( $p{min_level} ) };
+    Carp::croak "Invalid level specified for min_level"
         unless defined $self->{min_level};
 
     # Either use the parameter supplied or just the highest possible level.
-    $self->{max_level} = (
-        exists $p{max_level}
-        ? $self->_level_as_number( $p{max_level} )
-        : $#{ $self->{level_names} }
-    );
+    eval {
+        $self->{max_level} = (
+            exists $p{max_level}
+            ? $self->_level_as_number( $p{max_level} )
+            : $#{ $self->{level_names} }
+        );
+    };
 
-    die "Invalid level specified for max_level"
+    Carp::croak "Invalid level specified for max_level"
         unless defined $self->{max_level};
 
     my @cb = $self->_get_callbacks(%p);
@@ -128,11 +130,11 @@ sub _level_as_number {
         Carp::croak "undefined value provided for log level";
     }
 
-    return $level if $level =~ /^\d$/;
-
     unless ( Log::Dispatch->level_is_valid($level) ) {
         Carp::croak "$level is not a valid Log::Dispatch log level";
     }
+
+    return $level if $level =~ /\A[0-9]+\z/;
 
     return $self->{level_numbers}{$level};
 }
@@ -145,7 +147,12 @@ sub _level_as_name {
         Carp::croak "undefined value provided for log level";
     }
 
-    return $level unless $level =~ /^\d$/;
+    my $canonical_level;
+    unless ( $canonical_level = Log::Dispatch->level_is_valid($level) ) {
+        Carp::croak "$level is not a valid Log::Dispatch log level";
+    }
+
+    return $canonical_level unless $level =~ /\A[0-9]+\z/;
 
     return $self->{level_names}[$level];
 }


### PR DESCRIPTION
Having started working on RT bug #106495, I subsequently realised that the issue
had been resolved with GitHub PR #15. As I have a handful of modest improvements
left over from this work, I figured that I might as well submit them.

Note that this patch addresses the following discrepancy:-

    # Assuming one log output where min_level = 0 ...
    $dispatcher->is_debug()         # is true
    $dispatcher->would_log('debug') # is true
    $dispatcher->would_log(0)       # is false

* Make level_is_valid() able to validate - and canonicalise - levels given as
  numbers, not just names
* Remove redundant canonicalisation of numerical level from log()
* In _level_as_number(), only return given level once validation has occurred
* In _level_as_number(), following validation, only return the level as-is if it
  looks like an unsigned integer of any length [1]
* In _level_as_name(), also check - and canonicalise - the given level with
  level_is_valid() [2]
* In _level_as_name(), following validation, only return the level as-is if it
  does not look like an unsigned integer of any length [1]
* Use ASCII-safe semantics (can't use /a modifier but [0-9] is safer than \d)
* Where min_level/max_level are specified incorrectly, croak instead of dying
* In _basic_init, use eval to suppress exceptions raised by _level_as_number(),
  so that we can continue to throw user-friendly exceptions where min_level or
  max_level are specified incorrectly

[1] DRY principle; validation having already been conducted by level_is_valid()
[2] Establishes symmetry with _level_as_number(), which also validates