### PR TITLE
add note in File output about shared logs

### DIFF
--- a/lib/Log/Dispatch/File.pm
+++ b/lib/Log/Dispatch/File.pm
@@ -200,6 +200,13 @@ Log::Dispatch::* system.
 Note that a newline will I<not> be added automatically at the end of a message
 by default. To do that, pass C<< newline => 1 >>.
 
+B<NOTE:> If you are writing to the log file from multiple processes, the
+log output may become interleaved and garbled. To fix this, you can use
+the C<syswrite> attribute and set C<mode> to C<< '>>' >> for "append",
+but this can fail if the log message is too large. The best solution to
+sharing a log file from multiple processes is to use the
+L<Log::Dispatch::File::Locked> output instead.
+
 =head1 CONSTRUCTOR
 
 The constructor takes the following parameters in addition to the standard


### PR DESCRIPTION
When using a log file from multiple processes, it may become garbled if
steps are not taken. The File docs now explicitly mention this problem
and offer a couple solutions for it.

Fixes #31