### PR TITLE
earlier version of Log::Dispatch::File::Stamped breaks with 2.59 refa…

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+ - Updated a conflict entry for older Log::Dispatch::File::Stamped in metadata
+   (due to changes in handling of close_after_write).
+
+
 2.62     2017-02-13
 
 - Devel::Confess was accidentally being loaded in Log::Dispatch. Fixed by

--- a/dist.ini
+++ b/dist.ini
@@ -37,4 +37,4 @@ skip = Log/Dispatch/Conflicts.pm
 finder = MostLibs
 
 [Conflicts]
-Log::Dispatch::File::Stamped = 0.10
+Log::Dispatch::File::Stamped = 0.17


### PR DESCRIPTION
…ctoring

The 'close_after_write' option used to be stored in the 'close' key, but
is now in 'close_after_write'; LDFS's code references that option.