### PR TITLE
Use octal permission notation for chmod error msg

### DIFF
--- a/lib/Log/Dispatch/File.pm
+++ b/lib/Log/Dispatch/File.pm
@@ -103,8 +103,10 @@ sub _open_file {
         my $current_mode = ( stat $self->{filename} )[2] & 07777;
         if ( $current_mode ne $self->{permissions} ) {
             chmod $self->{permissions}, $self->{filename}
-                or die
-                "Cannot chmod $self->{filename} to $self->{permissions}: $!";
+                or die sprintf(
+                'Cannot chmod %s to %04o: %s',
+                $self->{filename}, $self->{permissions} & 07777, $!
+                );
         }
 
         $self->{chmodded} = 1;


### PR DESCRIPTION
Improve the readability of of the chmod error message in _open_file()
by changing the permission output from decimal notation to octal
notation.

Resolves: #43