### PR TITLE
Fix the ApacheLog constructor

### DIFF
--- a/lib/Log/Dispatch/ApacheLog.pm
+++ b/lib/Log/Dispatch/ApacheLog.pm
@@ -27,7 +27,7 @@ use base qw( Log::Dispatch::Output );
 
     sub new {
         my $class = shift;
-        my %p     = validator->(@_);
+        my %p     = $validator->(@_);
 
         my $self = bless { apache_log => ( delete $p{apache} )->log }, $class;
         $self->_basic_init(%p);


### PR DESCRIPTION
the constructor was doing validator->(@_), but there is no subroutine
called validator so this fails.  It should have been $validator->(@_)