### PR TITLE
implement lazy_open for Log::Dispatch::File

### DIFF
--- a/lib/Log/Dispatch/File.pm
+++ b/lib/Log/Dispatch/File.pm
@@ -37,6 +37,10 @@ sub APPEND {0}
                 type    => t('Bool'),
                 default => 0,
             },
+            lazy_open => {
+                type    => t('Bool'),
+                default => 0,
+            },
             permissions => {
                 type     => t('PositiveOrZeroInt'),
                 optional => 1,
@@ -55,7 +59,7 @@ sub APPEND {0}
 
         my $self
             = bless { map { $_ => delete $p{$_} }
-                qw( filename binmode autoflush close_after_write permissions syswrite )
+                qw( filename binmode autoflush close_after_write lazy_open permissions syswrite )
             }, $class;
 
         if ( $self->{close_after_write} ) {
@@ -83,7 +87,7 @@ sub APPEND {0}
 sub _make_handle {
     my $self = shift;
 
-    $self->_open_file() unless $self->{close_after_write};
+    $self->_open_file() if !$self->{close_after_write} && !$self->{lazy_open};
 }
 
 sub _open_file {
@@ -126,6 +130,10 @@ sub log_message {
 
     if ( $self->{close_after_write} ) {
         $self->_open_file;
+    }
+    elsif ( $self->{lazy_open} ) {
+        $self->_open_file;
+        $self->{lazy_open} = 0;
     }
 
     my $fh = $self->{fh};
@@ -223,6 +231,11 @@ defaults to false.
 
 If this is true, then the mode will always be append, so that the file is not
 re-written for each new message.
+
+=item * lazy_open ($)
+
+Whether the file should be opened only on first write. This defaults
+to false.
 
 =item * autoflush ($)
 

--- a/t/lazy-open.t
+++ b/t/lazy-open.t
@@ -1,0 +1,68 @@
+use strict;
+use warnings FATAL => 'all';
+
+use Test::More 0.88;
+
+use File::Spec;
+use File::Temp qw( tempdir );
+use Log::Dispatch;
+
+my $dir = tempdir( CLEANUP => 1 );
+
+{
+    my $logger = Log::Dispatch->new(
+        outputs => [
+            [
+                'File',
+                min_level => 'debug',
+                newline   => 1,
+                name      => 'lazy_open',
+                filename  => File::Spec->catfile( $dir, 'lazy_open.log' ),
+                lazy_open => 1,
+            ],
+        ],
+    );
+
+    ok(
+        !$logger->output('lazy_open')->{fh},
+        'lazy_open output has not created a fh before first write'
+    );
+
+    $logger->log( level => 'info', message => 'first message' );
+    is(
+        _slurp( $logger->output('lazy_open')->{filename} ),
+        "first message\n",
+        'first line from lazy_open output'
+    );
+
+    ok(
+        $logger->output('lazy_open')->{fh},
+        'lazy_open output has still an open fh'
+    );
+
+    $logger->log( level => 'info', message => 'second message' );
+
+    is(
+        _slurp( $logger->output('lazy_open')->{filename} ),
+        "first message\nsecond message\n",
+        'full content from caw output'
+    );
+
+    ok(
+        $logger->output('lazy_open')->{fh},
+        'lazy_open output has still an open fh'
+    );
+}
+
+done_testing();
+
+sub _slurp {
+    open my $fh, '<', $_[0]
+        or die "Cannot read $_[0]: $!";
+    my $s = do {
+        local $/ = undef;
+        <$fh>;
+    };
+    close $fh or die $!;
+    return $s;
+}


### PR DESCRIPTION
For discussion: this change adds a new option lazy_open. Like close_after_write this does not open the log filehandle until it's needed. Unlike close_after_write this does not close the filehandle anymore.