### PR TITLE
Make log_and_{die,croak} doc match code

### DIFF
--- a/lib/Log/Dispatch.pm
+++ b/lib/Log/Dispatch.pm
@@ -440,8 +440,6 @@ C<log()> method.
 Has the same behavior as calling C<log()> but calls
 C<_die_with_message()> at the end.
 
-=head2 $dispatch->log_and_croak( level => $, message => $ or \& )
-
 This method adjusts the C<$Carp::CarpLevel> scalar so that the croak
 comes from the context in which it is called.
 
@@ -449,6 +447,10 @@ You can throw exception objects by subclassing this method.
 
 If the C<carp_level> parameter is present its value will be added to
 the current value of C<$Carp::CarpLevel>.
+
+=head2 $dispatch->log_and_croak( level => $, message => $ or \& )
+
+A synonym for C<$dispatch->log_and_die()>.
 
 =head2 $dispatch->log_to( name => $, level => $, message => $ )
 


### PR DESCRIPTION
log_and_croak() was recently made a synonym of log_and_die() ([in this
commit][commit]).

This adjusts the documentation to match.

[commit]: https://github.com/houseabsolute/Log-Dispatch/commit/a2a216b19be0f07868034f0057f5f05b1f881908#diff-1b4cc254700c5bb75d866c985d9dd69e

Closes #51.