### PR TITLE
warn $_ instead of warn $@, because Try::Tiny.

### DIFF
--- a/lib/Log/Dispatch/Syslog.pm
+++ b/lib/Log/Dispatch/Syslog.pm
@@ -95,8 +95,7 @@ my $thread_lock;
 
         lock($thread_lock) if $self->{lock};
 
-        return
-            if try {
+        try {
             if ( defined $self->{socket} ) {
                 Sys::Syslog::setlogsock(
                     ref $self->{socket}
@@ -113,11 +112,9 @@ my $thread_lock;
             );
             Sys::Syslog::syslog( $priorities[$pri], $p{message} );
             Sys::Syslog::closelog();
-
-            1;
-            };
-
-        warn $@ if $@ and $^W;
+        } catch {
+            warn $_ if $^W;
+        };
     }
 }
 

--- a/t/syslog-warn.t
+++ b/t/syslog-warn.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+
+use Test::More 0.88;
+
+use Log::Dispatch;
+use Log::Dispatch::Syslog;
+
+{
+    my $dispatch = Log::Dispatch->new;
+    $dispatch->add(
+        Log::Dispatch::Syslog->new(
+            name      => 'syslog',
+            min_level => 'debug',
+            #socket   => { type => 'tcp', host => '127.0.0.1', port => 514 },
+            # no connection to syslog available
+            # - getservbyname failed 
+            socket    => { type => 'tcp', port => '' },
+        )
+    );
+
+    my $warn = "";
+    local $SIG{__WARN__} = sub { $warn .= $_[0] };
+    local $^W = 1;
+    $dispatch->info('Foo');
+    like $warn, qr/no connection/;
+}
+
+done_testing();


### PR DESCRIPTION
Since there is a request #20, it may be good to be able to controll. 

* Log::Dispatch::Syslog->new( log_message_exception => none|warn|ignore )
* use warnings::register and warnings::enabled()