### PR TITLE
Use numeric level id in generated methods

### DIFF
--- a/lib/Log/Dispatch.pm
+++ b/lib/Log/Dispatch.pm
@@ -9,7 +9,8 @@ our $VERSION = '2.68';
 
 use Carp ();
 use Log::Dispatch::Types;
-use Log::Dispatch::Vars qw( %CanonicalLevelNames @OrderedLevels %LevelNamesToNumbers);
+use Log::Dispatch::Vars
+    qw( %CanonicalLevelNames @OrderedLevels %LevelNamesToNumbers);
 use Module::Runtime qw( use_package_optimistically );
 use Params::ValidationCompiler qw( validation_for );
 
@@ -17,8 +18,8 @@ use base qw( Log::Dispatch::Base );
 
 BEGIN {
     foreach my $l ( keys %CanonicalLevelNames ) {
-        my $level_id = $LevelNamesToNumbers{ $l };
-        my $sub = sub {
+        my $level_id = $LevelNamesToNumbers{$l};
+        my $sub      = sub {
             my $self = shift;
             $self->log(
                 level     => $CanonicalLevelNames{$l},
@@ -256,10 +257,10 @@ sub level_is_valid {
 }
 
 sub would_log {
-    my ($self, $level, $level_id) = @_;
+    my ( $self, $level, $level_id ) = @_;
 
     # assume that level is correct if ID given
-    if (! defined $level_id) {
+    if ( !defined $level_id ) {
         return 0 unless $self->level_is_valid($level);
     }
 

--- a/lib/Log/Dispatch/Output.pm
+++ b/lib/Log/Dispatch/Output.pm
@@ -147,7 +147,8 @@ sub _should_log {
     my $level    = shift;
     my $level_id = shift;
 
-    my $msg_level = $level_id // $self->_level_as_number($level);
+    my $msg_level
+        = defined $level_id ? $level_id : $self->_level_as_number($level);
     return (   ( $msg_level >= $self->{min_level} )
             && ( $msg_level <= $self->{max_level} ) );
 }

--- a/lib/Log/Dispatch/Output.pm
+++ b/lib/Log/Dispatch/Output.pm
@@ -39,7 +39,7 @@ sub new {
         my $self = shift;
         my %p    = $validator->(@_);
 
-        return unless $self->_should_log( $p{level} );
+        return unless $self->_should_log( $p{level}, $p{_level_id} );
 
         local $! = undef;
         $p{message} = $self->_apply_callbacks(%p)
@@ -129,9 +129,10 @@ sub accepted_levels {
 }
 
 sub _should_log {
-    my $self = shift;
+    my ( $self, $level, $level_id ) = @_;
 
-    my $msg_level = $self->_level_as_number(shift);
+    my $msg_level
+        = defined $level_id ? $level_id : $self->_level_as_number($level);
     return (   ( $msg_level >= $self->{min_level} )
             && ( $msg_level <= $self->{max_level} ) );
 }

--- a/lib/Log/Dispatch/Output.pm
+++ b/lib/Log/Dispatch/Output.pm
@@ -39,7 +39,7 @@ sub new {
         my $self = shift;
         my %p    = $validator->(@_);
 
-        return unless $self->_should_log( $p{level} );
+        return unless $self->_should_log( $p{level}, $p{_level_id} );
 
         local $! = undef;
         $p{message} = $self->_apply_callbacks(%p)
@@ -48,11 +48,12 @@ sub new {
         $self->log_message(%p);
     }
 
+    ## no critic (Subroutines::ProhibitUnusedPrivateSubroutines)
     sub _log_with_id {
         my $self = shift;
         my %p    = $validator->(@_);
 
-        return unless $self->_should_log_id( $p{_level_id} );
+        return unless $self->_should_log( undef, $p{_level_id} );
 
         local $! = undef;
         $p{message} = $self->_apply_callbacks(%p)
@@ -60,6 +61,7 @@ sub new {
 
         $self->log_message(%p);
     }
+    ## use critic
 }
 
 {
@@ -94,8 +96,7 @@ sub new {
         my $self = shift;
         my %p    = $validator->(@_);
 
-        $self->{level_names}   = \@OrderedLevels;
-        $self->{level_numbers} = \%LevelNamesToNumbers;
+        $self->{level_names} = \@OrderedLevels;
 
         $self->{name} = $p{name} || $self->_unique_name();
 
@@ -142,37 +143,23 @@ sub accepted_levels {
 }
 
 sub _should_log {
-    my $self = shift;
+    my $self     = shift;
+    my $level    = shift;
+    my $level_id = shift;
 
-    my $msg_level = $self->_level_as_number(shift);
+    my $msg_level = $level_id // $self->_level_as_number($level);
     return (   ( $msg_level >= $self->{min_level} )
             && ( $msg_level <= $self->{max_level} ) );
 }
 
-sub _should_log_id {
-    my $self      = shift;
-    my $msg_level = shift;
-
-    return (   ( $msg_level >= $self->{min_level} )
-            && ( $msg_level <= $self->{max_level} ) );
-}
-
+## no critic (Subroutines::ProtectPrivateSubs)
 sub _level_as_number {
-    my $self  = shift;
-    my $level = shift;
+    shift;
 
-    unless ( defined $level ) {
-        Carp::croak 'undefined value provided for log level';
-    }
-
-    unless ( Log::Dispatch->level_is_valid($level) ) {
-        Carp::croak "$level is not a valid Log::Dispatch log level";
-    }
-
-    return $level if $level =~ /\A[0-7]+\z/;
-
-    return $self->{level_numbers}{$level};
+    # should it be public?
+    return Log::Dispatch->_level_as_number(shift);
 }
+## use critic
 
 ## no critic (Subroutines::ProhibitUnusedPrivateSubroutines)
 sub _level_as_name {

--- a/t/basic.t
+++ b/t/basic.t
@@ -1237,11 +1237,13 @@ subtest(
             \@calls,
             [
                 {
-                    level   => 'error',
-                    message => 'foo',
+                    level     => 'error',
+                    _level_id => 4,
+                    message   => 'foo',
                 }, {
-                    level   => 'critical',
-                    message => 'baz',
+                    level     => 'critical',
+                    _level_id => 5,
+                    message   => 'baz',
                 },
             ],
             'code received the expected messages'


### PR DESCRIPTION
Added numeric log level id to arguments of generated debug(), info(),... methods.
Then it used to avoid extra string-to-id lookups and validation.