### PR TITLE
Use numeric level id in generated methods and elsewhere when we have it

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+- Speedups to the internals to avoid re-validating the same sets of parameters
+  repeatedly. Based on a PR #54 from Sergey Leschenko.
+
+
 2.67     2017-09-24
 
 - Added a lazy_open option to the File output. This delays opening the file

--- a/lib/Log/Dispatch.pm
+++ b/lib/Log/Dispatch.pm
@@ -16,7 +16,7 @@ use Params::ValidationCompiler qw( validation_for );
 use base qw( Log::Dispatch::Base );
 
 BEGIN {
-    foreach my $l ( keys %CanonicalLevelNames ) {
+    for my $l ( keys %CanonicalLevelNames ) {
         my $level_num = $LevelNamesToNumbers{$l};
         my $sub       = sub {
             my $self = shift;
@@ -75,7 +75,7 @@ BEGIN {
                 #   [ 'File',   min_level => 'debug', filename => 'logfile' ],
                 #   [ 'Screen', min_level => 'warning' ]
                 # ]
-                foreach my $arr ( @{$outputs} ) {
+                for my $arr ( @{$outputs} ) {
                     die "expected arrayref, not '$arr'"
                         unless ref $arr eq 'ARRAY';
                     $self->_add_output( @{$arr} );
@@ -189,7 +189,7 @@ sub _log_to_outputs {
     my $self = shift;
     my %p    = @_;
 
-    foreach ( values %{ $self->{outputs} } ) {
+    for ( values %{ $self->{outputs} } ) {
         $_->log(%p);
     }
 }
@@ -270,7 +270,7 @@ sub _would_log {
     my $self      = shift;
     my $level_num = shift;
 
-    foreach ( values %{ $self->{outputs} } ) {
+    for ( values %{ $self->{outputs} } ) {
         return 1 if $_->_should_log($level_num);
     }
 

--- a/lib/Log/Dispatch/Base.pm
+++ b/lib/Log/Dispatch/Base.pm
@@ -43,7 +43,7 @@ sub _apply_callbacks {
     my %p    = @_;
 
     my $msg = delete $p{message};
-    foreach my $cb ( @{ $self->{callbacks} } ) {
+    for my $cb ( @{ $self->{callbacks} } ) {
         $msg = $cb->( message => $msg, %p );
     }
 

--- a/lib/Log/Dispatch/Base.pm
+++ b/lib/Log/Dispatch/Base.pm
@@ -2,9 +2,40 @@ package Log::Dispatch::Base;
 
 use strict;
 use warnings;
+
+use Carp ();
+use Log::Dispatch::Vars
+    qw( %CanonicalLevelNames %LevelNamesToNumbers @OrderedLevels );
 use Scalar::Util qw( refaddr );
 
 our $VERSION = '2.68';
+
+## no critic (Subroutines::ProhibitUnusedPrivateSubroutines)
+sub _level_as_number {
+    my $self  = shift;
+    my $level = shift;
+
+    my $level_name = $self->level_is_valid($level);
+    return unless $level_name;
+
+    return $LevelNamesToNumbers{$level_name};
+}
+## use critic
+
+sub level_is_valid {
+    shift;
+    my $level = shift;
+
+    if ( !defined $level ) {
+        Carp::croak('Logging level was not provided');
+    }
+
+    if ( $level =~ /\A[0-9]+\z/ && $level <= $#OrderedLevels ) {
+        return $OrderedLevels[$level];
+    }
+
+    return $CanonicalLevelNames{$level};
+}
 
 ## no critic (Subroutines::ProhibitUnusedPrivateSubroutines)
 sub _apply_callbacks {
@@ -52,9 +83,7 @@ sub remove_callback {
 
 __END__
 
-=for Pod::Coverage add_callback
-
-=for Pod::Coverage remove_callback
+=for Pod::Coverage .*
 
 =head1 SYNOPSIS
 

--- a/lib/Log/Dispatch/Output.pm
+++ b/lib/Log/Dispatch/Output.pm
@@ -9,7 +9,7 @@ use Carp ();
 use Try::Tiny;
 use Log::Dispatch;
 use Log::Dispatch::Types;
-use Log::Dispatch::Vars qw( %LevelNamesToNumbers @OrderedLevels );
+use Log::Dispatch::Vars qw( @OrderedLevels );
 use Params::ValidationCompiler qw( validation_for );
 
 use base qw( Log::Dispatch::Base );
@@ -39,7 +39,8 @@ sub new {
         my $self = shift;
         my %p    = $validator->(@_);
 
-        return unless $self->_should_log( $p{level} );
+        my $level_num = $self->_level_as_number( $p{level} );
+        return unless $self->_should_log($level_num);
 
         local $! = undef;
         $p{message} = $self->_apply_callbacks(%p)
@@ -47,6 +48,22 @@ sub new {
 
         $self->log_message(%p);
     }
+
+    ## no critic (Subroutines::ProhibitUnusedPrivateSubroutines)
+    sub _log_with_num {
+        my $self      = shift;
+        my $level_num = shift;
+        my %p         = @_;
+
+        return unless $self->_should_log($level_num);
+
+        local $! = undef;
+        $p{message} = $self->_apply_callbacks(%p)
+            if $self->{callbacks};
+
+        $self->log_message(%p);
+    }
+    ## use critic
 }
 
 {
@@ -81,8 +98,7 @@ sub new {
         my $self = shift;
         my %p    = $validator->(@_);
 
-        $self->{level_names}   = \@OrderedLevels;
-        $self->{level_numbers} = \%LevelNamesToNumbers;
+        $self->{level_names} = \@OrderedLevels;
 
         $self->{name} = $p{name} || $self->_unique_name();
 
@@ -129,28 +145,11 @@ sub accepted_levels {
 }
 
 sub _should_log {
-    my $self = shift;
+    my $self      = shift;
+    my $level_num = shift;
 
-    my $msg_level = $self->_level_as_number(shift);
-    return (   ( $msg_level >= $self->{min_level} )
-            && ( $msg_level <= $self->{max_level} ) );
-}
-
-sub _level_as_number {
-    my $self  = shift;
-    my $level = shift;
-
-    unless ( defined $level ) {
-        Carp::croak 'undefined value provided for log level';
-    }
-
-    unless ( Log::Dispatch->level_is_valid($level) ) {
-        Carp::croak "$level is not a valid Log::Dispatch log level";
-    }
-
-    return $level if $level =~ /\A[0-7]+\z/;
-
-    return $self->{level_numbers}{$level};
+    return (   ( $level_num >= $self->{min_level} )
+            && ( $level_num <= $self->{max_level} ) );
 }
 
 ## no critic (Subroutines::ProhibitUnusedPrivateSubroutines)

--- a/t/basic.t
+++ b/t/basic.t
@@ -16,7 +16,7 @@ my %tests;
 
 BEGIN {
     local $@ = undef;
-    foreach (qw( MailSend MIMELite MailSendmail MailSender )) {
+    for (qw( MailSend MIMELite MailSendmail MailSender )) {
         ## no critic (BuiltinFunctions::ProhibitStringyEval, ErrorHandling::RequireCheckingReturnValueOfEval)
         eval "use Log::Dispatch::Email::$_";
         $tests{$_} = !$@;
@@ -555,7 +555,7 @@ subtest(
         @levels{qw( warn err crit emerg )}
             = (qw( warning error critical emergency ));
 
-        foreach my $allowed_level (
+        for my $allowed_level (
             qw( debug info notice warning error critical alert emergency )) {
             my $dispatch = Log::Dispatch->new;
 
@@ -569,7 +569,7 @@ subtest(
                 )
             );
 
-            foreach my $test_level (
+            for my $test_level (
                 qw( debug info notice warn warning err
                 error crit critical alert emerg emergency )
             ) {
@@ -630,14 +630,14 @@ subtest(
 subtest(
     'Log::Dispatch->level_is_valid method',
     sub {
-        foreach my $l (
+        for my $l (
             qw( debug info notice warning err error
             crit critical alert emerg emergency )
         ) {
             ok( Log::Dispatch->level_is_valid($l), "$l is valid level" );
         }
 
-        foreach my $l (qw( debu inf foo bar )) {
+        for my $l (qw( debu inf foo bar )) {
             ok( !Log::Dispatch->level_is_valid($l), "$l is not valid level" );
         }
 


### PR DESCRIPTION
Instead of passing the level name around and turning it into a number over and
over, we now turn it into a number once at a public method entry point and
pass that number through to private methods instead of calling public methods
again.

This provides a speed increase in two ways. First, we do much less
validation. Previously we would repeatedly validate the same set of args in
many cases. Two, we only do the name->number lookup once.