### PR TITLE
initialize $? with a numeric value

### DIFF
--- a/lib/Log/Dispatch/Email/MailSender.pm
+++ b/lib/Log/Dispatch/Email/MailSender.pm
@@ -65,7 +65,7 @@ sub send_email {
     my $self = shift;
     my %p    = @_;
 
-    local ( $?, $@, $SIG{__DIE__} ) = ( undef, undef, undef );
+    local ( $?, $@, $SIG{__DIE__} ) = ( 0, undef, undef );
     return
         if eval {
         my $sender = Mail::Sender->new(


### PR DESCRIPTION
Assignments to $? are coerced to numeric, so it should not be
initialized to undef.

Fixes #57