### PR TITLE
Improve test resilience on very slow-to-lock filesystems (I.E. nfs4)

### DIFF
--- a/t/file-locked.t
+++ b/t/file-locked.t
@@ -45,8 +45,8 @@ sub _run_children {
     my %exit_status;
     try {
         local $SIG{ALRM}
-            = sub { die 'Waited 10 seconds for children to exit' };
-        alarm 10;
+            = sub { die 'Waited 30 seconds for children to exit' };
+        alarm 30;
 
         while ( keys %pids ) {
             my $pid = waitpid( -1, WNOHANG );


### PR DESCRIPTION
This addresses #60 