### PR TITLE
Log::Dispatch:Screen: fix encoding test

### DIFF
--- a/t/screen-helper.pl
+++ b/t/screen-helper.pl
@@ -26,7 +26,10 @@ my $dispatch = Log::Dispatch->new(
 );
 
 my $message = 'test message';
-$message .= " - \x{1f60}" if $utf8;
+if ($utf8) {
+    binmode( $stderr ? \*STDERR : \*STDOUT );
+    $message .= " - \x{1f60}";
+}
 $dispatch->warning($message);
 
 exit 0;


### PR DESCRIPTION
The STD{IN,OUT,ERR} default handles start out in some unspecified (platform-specific) text encoding. The 'utf8' option of Log::Dispatch::Screen manually encodes the logged messages as bytes in UTF-8 format before writing them to the output handle. Thus, by default, the UTF-8 bytes get re-encoded by whatever the native text encoding is on the platform.

The correct way to handle this is to either not set 'utf8' (and rely on the encoding layer of the handle) or set 'utf8' and call binmode() on the handle (or otherwise apply a ':raw' layer) to ensure that bytes are written as is (without further re-encoding).

Fixes #32.